### PR TITLE
add a lower bound 0.68.5 for hsc2hs tool dependency

### DIFF
--- a/posix-api.cabal
+++ b/posix-api.cabal
@@ -90,7 +90,7 @@ library
   c-sources: cbits/HaskellPosix.c
   include-dirs: include
   includes: HaskellPosix.h
-  build-tools: hsc2hs
+  build-tool-depends: hsc2hs:hsc2hs >= 0.68.5
 
 test-suite test
   type: exitcode-stdio-1.0


### PR DESCRIPTION
This will resolve https://github.com/andrewthad/posix-api/issues/1. It can be merged when `hsc2hs-0.68.5` is released.